### PR TITLE
feat: authorize dbal ^3.0 for sylius 1.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.0",
-        "doctrine/dbal": "^2.7.0",
+        "doctrine/dbal": "^2.7 || ^3.0",
         "doctrine/migrations": "^3.0",
         "doctrine/orm": "^2.12",
         "psr/log": "^2.0",


### PR DESCRIPTION
Hi !

This PR authorize dbal ^3.0 to match with sylius requirements.

Package | Version | Requires |
---------|---------|----------------------------------------- |
sylius/sylius  |  v1.12.10  |  requires  doctrine/dbal (^2.7 \|\| ^3.0) |
sylius/sylius   |  v1.12.10  |   requires  doctrine/doctrine-bundle (^1.12 \|\| ^2.0)
doctrine/doctrine-bundle  |  2.10.2 | requires  doctrine/dbal (^3.6.0) |
