### PR TITLE
Show how to add plugin's scripts to Webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,32 @@ bin/console assets:install
 bin/console sylius:theme:assets:install
 ```
 
-6. Rebuild cache:
+6. Install the plugin JS assets by adding the source to your webpack configuration:
+
+```js
+// Shop config
+Encore.setOutputPath('public/build/shop/')
+    .setPublicPath('/build/shop')
+    .addEntry('shop-entry', './vendor/sylius/sylius/src/Sylius/Bundle/ShopBundle/Resources/private/entry.js')
+    .addEntry('webgriffe-sylius-back-in-stock-notification-entry', './vendor/webgriffe/sylius-back-in-stock-notification-plugin/public/js/back-in-stock-notification.js') // The line to add
+    .disableSingleRuntimeChunk()
+    .cleanupOutputBeforeBuild()
+    .enableSourceMaps(!Encore.isProduction())
+    .enableVersioning(Encore.isProduction())
+    .enablePostCssLoader()
+    .enableSassLoader()
+```
+
+7. Run yarn build:
+
+```bash
+bin/console yarn:build
+```
+
+8. Clear cache:
 
 ```bash
 bin/console cache:clear
-bin/console cache:warmup
 ```
 
 ## Configuration

--- a/templates/_configurableButton.html.twig
+++ b/templates/_configurableButton.html.twig
@@ -1,8 +1,13 @@
 {% if product.isConfigurable %}
-    <div id="sylius-variants-stock" data-option-code="{{ product.variants.first.optionValues|map(optionValue => "#{optionValue.optionCode}")|json_encode }}">
+    <div id="sylius-variants-stock"
+         data-option-code="{{ product.variants.first.optionValues|map(optionValue => "#{optionValue.optionCode}")|json_encode }}">
         {% for variant in product.variants %}
-            <div data-options-value="{{ variant.optionValues|map(optionValue => "#{optionValue.code}")|json_encode }}" data-available="{{ sylius_inventory_is_available(variant) }}" data-variant-code="{{ variant.code }}"></div>
+            <div data-options-value="{{ variant.optionValues|map(optionValue => "#{optionValue.code}")|json_encode }}"
+                 data-available="{{ sylius_inventory_is_available(variant) }}"
+                 data-variant-code="{{ variant.code }}"></div>
         {% endfor %}
     </div>
-    <button type="button" id="trigger-notification-overlay" class="ui huge primary icon labeled button" style="display: none"><i class="bell icon"></i> {{ 'webgriffe_bisn.product_page.form_action'|trans }}</button>
+    <button type="button" id="trigger-notification-overlay" class="ui huge primary icon labeled button"
+            style="display: none"><i class="bell icon"></i> {{ 'webgriffe_bisn.product_page.form_action'|trans }}
+    </button>
 {% endif %}

--- a/templates/_javascript.html.twig
+++ b/templates/_javascript.html.twig
@@ -1,1 +1,1 @@
-<script type="text/javascript" src="{{ asset('bundles/webgriffesyliusbackinstocknotificationplugin/js/back-in-stock-notification.js') }}" defer></script>
+{{ encore_entry_script_tags('webgriffe-sylius-back-in-stock-notification-entry', null, 'shop') }}

--- a/templates/productSubscriptionForm.html.twig
+++ b/templates/productSubscriptionForm.html.twig
@@ -1,15 +1,23 @@
 {% form_theme form '@SyliusShop/Form/theme.html.twig' %}
-<div class="ui segment">
+
+<div class="ui segment" style="margin-top: 5px">
     <h4 class="ui dividing header">{{ 'webgriffe_bisn.product_page.stock_notify_title'|trans }}</h4>
 
-    {{ form_start(form, {'attr': {'class': 'ui form form-default', 'id': 'back_in_stock_not'}, 'action': path('webgriffe_back_in_stock_notification_add_subscription')}) }}
+    {{ form_start(form, {
+        'attr': {'class': 'ui form form-default', 'id': 'back_in_stock_not'},
+        'action': path('webgriffe_back_in_stock_notification_add_subscription')
+    }) }}
+
     {% if form.email is defined %}
         {{ form_row(form.email, {'attr': {'data-test-fill-subscription-form-whit-my-email':''}}) }}
     {% endif %}
 
     {{ form_row(form.product_variant_code, {'attr': {'data-test-add-email-to-back-in-stock-notification-list':''}}) }}
 
-    <button type="submit" class="ui huge primary icon labeled button" {{ sylius_test_html_attribute('subscribe-to-notifications') }}><i class="bell icon"></i> {{ 'webgriffe_bisn.product_page.form_action'|trans }}</button>
+    <button type="submit" class="ui huge primary icon labeled button" {{ sylius_test_html_attribute('subscribe-to-notifications') }}>
+        <i class="bell icon"></i> {{ 'webgriffe_bisn.product_page.form_action'|trans }}
+    </button>
+
     {{ form_row(form._token) }}
     {{ form_end(form, {'render_rest': false}) }}
 </div>

--- a/tests/Application/webpack.config.js
+++ b/tests/Application/webpack.config.js
@@ -10,6 +10,7 @@ Encore
   .setOutputPath('public/build/shop/')
   .setPublicPath('/build/shop')
   .addEntry('shop-entry', '../../vendor/sylius/sylius/src/Sylius/Bundle/ShopBundle/Resources/private/entry.js')
+  .addEntry('webgriffe-sylius-back-in-stock-notification-entry', '../../public/js/back-in-stock-notification.js')
   .disableSingleRuntimeChunk()
   .cleanupOutputBeforeBuild()
   .enableSourceMaps(!Encore.isProduction())


### PR DESCRIPTION
From Sylius 1.12 we can assume that Webpack is the default frontend tool used to import and build JS.