### PR TITLE
fix(email): reinforcement of the validator and skip invalid address when sending alerts

### DIFF
--- a/src/Command/AlertCommand.php
+++ b/src/Command/AlertCommand.php
@@ -12,6 +12,7 @@ use Sylius\Component\Mailer\Sender\SenderInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Mime\Exception\RfcComplianceException;
 use Symfony\Component\Routing\RouterInterface;
 use Webgriffe\SyliusBackInStockNotificationPlugin\Entity\SubscriptionInterface;
 use Webgriffe\SyliusBackInStockNotificationPlugin\Repository\SubscriptionRepositoryInterface;
@@ -44,27 +45,32 @@ final class AlertCommand extends Command
         //I think that this load in the long time can be a bottle necklace
         $subscriptions = $this->backInStockNotificationRepository->findBy(['notify' => false]);
         foreach ($subscriptions as $subscription) {
-            $channel = $subscription->getChannel();
-            $productVariant = $subscription->getProductVariant();
-            if ($productVariant === null || $channel === null) {
-                $this->backInStockNotificationRepository->remove($subscription);
-                $this->logger->warning(
-                    'The back in stock subscription for the product does not have all the information required',
-                    ['subscription' => var_export($subscription, true)],
-                );
+            try {
+                $channel = $subscription->getChannel();
+                $productVariant = $subscription->getProductVariant();
+                if ($productVariant === null || $channel === null) {
+                    $this->backInStockNotificationRepository->remove($subscription);
+                    $this->logger->warning(
+                        'The back in stock subscription for the product does not have all the information required',
+                        ['subscription' => var_export($subscription, true)],
+                    );
 
-                continue;
-            }
+                    continue;
+                }
 
-            if (
-                $this->availabilityChecker->isStockAvailable($productVariant) &&
-                $productVariant->isEnabled() &&
-                $productVariant->getProduct()?->isEnabled() === true
-            ) {
-                $this->router->getContext()->setHost($channel->getHostname() ?? 'localhost');
-                $this->sendEmail($subscription, $productVariant, $channel);
-                $subscription->setNotify(true);
-                $this->backInStockNotificationRepository->add($subscription);
+                if (
+                    $this->availabilityChecker->isStockAvailable($productVariant) &&
+                    $productVariant->isEnabled() &&
+                    $productVariant->getProduct()?->isEnabled() === true
+                ) {
+                    $this->router->getContext()->setHost($channel->getHostname() ?? 'localhost');
+                    $this->sendEmail($subscription, $productVariant, $channel);
+                    $subscription->setNotify(true);
+                    $this->backInStockNotificationRepository->add($subscription);
+                }
+            } catch (RfcComplianceException $e) {
+                // Invalid email address, continue to the next one
+                $this->logger->warning($e->getMessage());
             }
         }
 

--- a/src/Command/AlertCommand.php
+++ b/src/Command/AlertCommand.php
@@ -42,7 +42,7 @@ final class AlertCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        //I think that this load in the long time can be a bottle necklace
+        // I think that this load in the long time can be a bottleneck
         $subscriptions = $this->backInStockNotificationRepository->findBy(['notify' => false]);
         foreach ($subscriptions as $subscription) {
             $channel        = $subscription->getChannel();

--- a/src/Command/AlertCommand.php
+++ b/src/Command/AlertCommand.php
@@ -45,32 +45,33 @@ final class AlertCommand extends Command
         //I think that this load in the long time can be a bottle necklace
         $subscriptions = $this->backInStockNotificationRepository->findBy(['notify' => false]);
         foreach ($subscriptions as $subscription) {
-            try {
-                $channel = $subscription->getChannel();
-                $productVariant = $subscription->getProductVariant();
-                if ($productVariant === null || $channel === null) {
-                    $this->backInStockNotificationRepository->remove($subscription);
-                    $this->logger->warning(
-                        'The back in stock subscription for the product does not have all the information required',
-                        ['subscription' => var_export($subscription, true)],
-                    );
+            $channel        = $subscription->getChannel();
+            $productVariant = $subscription->getProductVariant();
+            if ($productVariant === null || $channel === null) {
+                $this->backInStockNotificationRepository->remove($subscription);
+                $this->logger->warning(
+                    'The back in stock subscription for the product does not have all the information required',
+                    ['subscription' => var_export($subscription, true)],
+                );
 
+                continue;
+            }
+
+            if (
+                $this->availabilityChecker->isStockAvailable($productVariant) &&
+                $productVariant->isEnabled() &&
+                $productVariant->getProduct()?->isEnabled() === true
+            ) {
+                $this->router->getContext()->setHost($channel->getHostname() ?? 'localhost');
+
+                try {
+                    $this->sendEmail($subscription, $productVariant, $channel);
+                } catch (RfcComplianceException $e) {
+                    $this->logger->warning('Invalid email address, continue to the next one: ' . $e->getMessage());
                     continue;
                 }
-
-                if (
-                    $this->availabilityChecker->isStockAvailable($productVariant) &&
-                    $productVariant->isEnabled() &&
-                    $productVariant->getProduct()?->isEnabled() === true
-                ) {
-                    $this->router->getContext()->setHost($channel->getHostname() ?? 'localhost');
-                    $this->sendEmail($subscription, $productVariant, $channel);
-                    $subscription->setNotify(true);
-                    $this->backInStockNotificationRepository->add($subscription);
-                }
-            } catch (RfcComplianceException $e) {
-                // Invalid email address, continue to the next one
-                $this->logger->warning($e->getMessage());
+                $subscription->setNotify(true);
+                $this->backInStockNotificationRepository->add($subscription);
             }
         }
 

--- a/src/Form/SubscriptionType.php
+++ b/src/Form/SubscriptionType.php
@@ -25,7 +25,7 @@ final class SubscriptionType extends AbstractType
             ->add('email', EmailType::class, [
                 'constraints' => [
                     new NotBlank([], null, null, null, ['webgriffe_sylius_back_in_stock_notification_plugin']),
-                    new Email([], null, null, null, ['webgriffe_sylius_back_in_stock_notification_plugin']),
+                    new Email(['mode' => Email::VALIDATION_MODE_STRICT], null, null, null, ['webgriffe_sylius_back_in_stock_notification_plugin']),
                 ],
             ])
             ->add('product_variant_code', HiddenType::class)


### PR DESCRIPTION
Hi, 

On the last version for Sylius 1.X, version 4.1.0, we had a bug blocking the sending of alerts. 

Indeed, if the email format was incorrect, we had an RfcComplianceException. 
A person try an injection with this kind of email : `mauralien21@gmail.com'&&sleep(27*1000)*ckfqsx&&'` just by changing the input type from email to text, the backend Email validator accept this email. 
To prevent that I add it the redtriction mode : `Email::VALIDATION_MODE_STRICT`  

On alert sending, I had a try catch to no stop alert sending on email error. 

If you accept this PR, can we have an 4.1.1 or 4.2.0 tags for Sylius 1 pls ? 

Have a nice day ! 

Kind regards,
Kévin 